### PR TITLE
Download and Use Bootstrapper at runtime and app installation time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ ARM64/
 
 bin/
 obj/
+
+# Don't check in bootstrapper downloaded at runtime
+MicrosoftEdgeWebview2Setup.exe

--- a/SampleApps/WebView2APISample/App.cpp
+++ b/SampleApps/WebView2APISample/App.cpp
@@ -14,6 +14,9 @@
 #include <vector>
 #include "AppWindow.h"
 #include "DpiUtil.h"
+#include <iostream>
+
+using namespace std;
 
 HINSTANCE g_hInstance;
 int g_nCmdShow;
@@ -32,6 +35,29 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
                       PWSTR lpCmdLine,
                       int nCmdShow)
 {
+
+    // fkwlink. Download
+    //HRESULT hr = URLDownloadToFile(NULL, L"http://ie-snap/scratchtests/xiaqu/MicrosoftEdgeWebview2Setup.exe", L".\\MicrosoftEdgeWebview2Setup.exe", 0, 0);
+
+    // Package and Install at Runtime
+    //SHELLEXECUTEINFO shExInfo = {0};
+    //shExInfo.cbSize = sizeof(shExInfo);
+    //shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+    //shExInfo.hwnd = 0;
+    //shExInfo.lpVerb = L"runas";
+    ////shExInfo.lpFile = L"MicrosoftEdgeUpdateSetup_WebView.exe";
+    //shExInfo.lpFile = L"MicrosoftEdgeWebview2Setup.exe";
+    //shExInfo.lpParameters = L" /silent /install";
+    //shExInfo.lpDirectory = 0;
+    //shExInfo.nShow = 0;
+    //shExInfo.hInstApp = 0;  
+
+    //if (ShellExecuteEx(&shExInfo))
+    //{
+    //    WaitForSingleObject(shExInfo.hProcess, INFINITE);
+    //    CloseHandle(shExInfo.hProcess);
+    //}
+
     g_hInstance = hInstance;
     UNREFERENCED_PARAMETER(hPrevInstance);
     g_nCmdShow = nCmdShow;

--- a/SampleApps/WebView2APISample/App.cpp
+++ b/SampleApps/WebView2APISample/App.cpp
@@ -36,10 +36,11 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
                       int nCmdShow)
 {
 
-    // fkwlink. Download
+    // Use fkwlink to download WebView2 Bootstrapper at runtime
     //HRESULT hr = URLDownloadToFile(NULL, L"http://ie-snap/scratchtests/xiaqu/MicrosoftEdgeWebview2Setup.exe", L".\\MicrosoftEdgeWebview2Setup.exe", 0, 0);
 
-    // Package and Install at Runtime
+    // Either Package the WebView2 Bootstrapper with your app or download it 
+    // Then invoke install at Runtime
     //SHELLEXECUTEINFO shExInfo = {0};
     //shExInfo.cbSize = sizeof(shExInfo);
     //shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;

--- a/SampleApps/WebView2APISample/WebView2APISample.vcxproj
+++ b/SampleApps/WebView2APISample/WebView2APISample.vcxproj
@@ -258,6 +258,8 @@
     <CopyFileToFolders Include="ScenarioJavaScriptDebugIndex.js" />
     <CopyFileToFolders Include="ScenarioTypeScriptDebugIndex.html" />
     <CopyFileToFolders Include="ScenarioTypeScriptDebugIndex.ts" />
+    <!-- Bootstrapper downloaded during runtime. Copy to output folder
+    <CopyFileToFolders Include="MicrosoftEdgeUpdateSetup_WebView.exe" /> -->
   </ItemGroup>
   <ItemGroup>
     <Midl Include="HostObjectSample.idl" TypeLibraryName="$(OutDir)WebView2APISample.tlb" />

--- a/SampleApps/WebView2APISample/WebView2APISample.vcxproj.filters
+++ b/SampleApps/WebView2APISample/WebView2APISample.vcxproj.filters
@@ -142,6 +142,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="$(MSBuildThisFileDirectory)$(EffectivePlatform)\WebView2Loader.dll" />
+    <None Include="MicrosoftEdgeUpdateSetup_WebView.exe" />
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="ScenarioWebMessage.html" />

--- a/SampleApps/WebView2PackageMsi/Product.wxs
+++ b/SampleApps/WebView2PackageMsi/Product.wxs
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+	<Product Id="*" Name="WebView2PackageMsi" Language="1033" Version="1.0.0.0" Manufacturer="Microsoft Corp." UpgradeCode="747c5e4c-5e28-4fbf-b7ba-f382b55dd9c4">
+		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine"/>
+		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed."/>
+    <MediaTemplate EmbedCab="yes"/>
+        
+		<!-- Step 1: Define installation folder -->
+		<Directory Id="TARGETDIR" Name="SourceDir">
+			<Directory Id="ProgramFiles64Folder">
+				<Directory Id="INSTALLFOLDER" Name="WebView2PackageMsi"/>
+			</Directory>
+		</Directory>
+		
+		<!-- Step 2: Add files to your installer package -->
+		<DirectoryRef Id="INSTALLFOLDER">
+			<Component Id="WebView2APISample.exe" Guid="2DC56D26-A5CC-40ED-81C5-441042F2C46B">
+				<File Id="WebView2APISample.exe" Source="..\WebView2APISample\Debug\x64\WebView2APISample.exe" KeyPath="yes" Checksum="yes"/>
+			</Component>
+			<Component Id="WebView2Loader.dll" Guid="624B4B28-4D7F-49D8-9CAD-279FC2AC8D25">
+				<File Id="WebView2Loader.dll" Source="..\WebView2APISample\Debug\x64\WebView2Loader.dll" KeyPath="yes"/>
+			</Component>
+			<!-- [Package Bootstrapper] Package bootstrapper with your app -->
+			<!--<Component Id="MicrosoftEdgeWebview2Setup.exe" Guid="777B0F5C-51C3-4A39-AC5A-88E5A2640D48">
+				<File Id="MicrosoftEdgeWebview2Setup.exe" Source="..\WebView2APISample\Debug\x86\MicrosoftEdgeWebview2Setup.exe" KeyPath="yes"/>
+			</Component>-->
+		</DirectoryRef>
+
+		<!-- Step 3: Tell WiX to install the files -->
+		<Feature Id="MainApplication" Title="Main Application" Level="1" ConfigurableDirectory='INSTALLFOLDER'>
+			<ComponentRef Id="WebView2APISample.exe"/>
+			<ComponentRef Id="WebView2Loader.dll"/>
+      
+			<!-- [Package Bootstrapper] Package bootstrapper with your app -->
+			<!--<ComponentRef Id="MicrosoftEdgeWebview2Setup.exe" />-->
+		</Feature>
+
+		<!--Custom UI. Let User choose install location-->
+		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
+		<UIRef Id="WixUI_InstallDir"/>
+
+		<!-- [Package Bootstrapper] Package bootstrapper then invoke at app installation-->
+		<!--<CustomAction Id='InvokeBootstrapper' FileKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" Impersonate="no" ExeCommand=' ' Return='check' />-->
+		
+		<!-- [Download Bootstrapper] Use fwlink to download bootstrapper to user TEMP folder then invoke it-->
+		<Property Id='POWERSHELL'>powershell.exe</Property>
+		<CustomAction Id='DownloadBootstrapper' Property='POWERSHELL' ExeCommand='Invoke-WebRequest -Uri "http://ie-snap/scratchtests/xiaqu/MicrosoftEdgeWebview2Setup.exe" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe"' Return='check'/>
+		<CustomAction Id='InvokeBootstrapper' Directory="INSTALLFOLDER" Execute="deferred" Impersonate="no" ExeCommand='cmd.exe /c %temp%\MicrosoftEdgeWebview2Setup.exe /silent /install' Return='check'/>
+		
+		<!-- Custom action to invoke for download and install bootstrapper -->
+		<InstallExecuteSequence>
+			<!-- [Package Bootstrapper] Package bootstrapper and invoke at app installation-->
+			<!--<Custom Action='LaunchFile' Before='InstallFinalize'/>-->
+
+			<!-- [Download Bootstrapper] Use fwlink to download the bootstrapper to user TEMP folder and invoke-->
+			<Custom Action='DownloadBootstrapper' Before='InstallFinalize'/>
+			<Custom Action='InvokeBootstrapper' After='DownloadBootstrapper'/>
+		</InstallExecuteSequence>
+	</Product>
+</Wix>

--- a/SampleApps/WebView2PackageMsi/WebView2PackageMsi.wixproj
+++ b/SampleApps/WebView2PackageMsi/WebView2PackageMsi.wixproj
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>2edd9077-0b48-48ae-ae59-69b92823cb90</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>WebView2PackageMsi</OutputName>
+    <OutputType>Package</OutputType>
+    <Name>WebView2PackageMsi</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|ARM64' ">
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Product.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WebView2APISample\WebView2APISample.vcxproj">
+      <Name>WebView2APISample</Name>
+      <Project>{4f0ceef3-12b3-425e-9bb0-105200411592}</Project>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixUIExtension">
+      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
+      <Name>WixUIExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
+  <!--
+	To modify your build process, add your task inside one of the targets below and uncomment it.
+	Other similar extension points exist, see Wix.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/SampleApps/WebView2Samples.sln
+++ b/SampleApps/WebView2Samples.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebView2WindowsFormsBrowser
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebView2WpfBrowser", "WebView2WpfBrowser\WebView2WpfBrowser.csproj", "{68762FAD-5D35-4D53-B15B-36B521C4494E}"
 EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "WebView2PackageMsi", "WebView2PackageMsi\WebView2PackageMsi.wixproj", "{2EDD9077-0B48-48AE-AE59-69B92823CB90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,22 @@ Global
 		{68762FAD-5D35-4D53-B15B-36B521C4494E}.Release|x64.Build.0 = Release|Any CPU
 		{68762FAD-5D35-4D53-B15B-36B521C4494E}.Release|x86.ActiveCfg = Release|Any CPU
 		{68762FAD-5D35-4D53-B15B-36B521C4494E}.Release|x86.Build.0 = Release|Any CPU
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|Any CPU.Build.0 = Debug|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|ARM64.Build.0 = Debug|ARM64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|x64.ActiveCfg = Debug|x64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|x64.Build.0 = Debug|x64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|x86.ActiveCfg = Debug|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Debug|x86.Build.0 = Debug|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|Any CPU.ActiveCfg = Release|x86
+	    {2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|Any CPU.Build.0 = Release|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|ARM64.ActiveCfg = Release|ARM64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|ARM64.Build.0 = Release|ARM64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|x64.ActiveCfg = Release|x64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|x64.Build.0 = Release|x64
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|x86.ActiveCfg = Release|x86
+		{2EDD9077-0B48-48AE-AE59-69B92823CB90}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Verify and write sample code to following cases:
- Package bootstrapper with msi package and invoke at app installation time 
- Package bootstrapper with msi package and invoke at app runtime
- Download bootstrapper and invoke at app installation time
- Download bootstrapper and invoke at app runtime

Notes:
- Download at app installation time is downloading to user TEMP folder
- At app runtime, invoking the bootstrapper using runas will prompt user for consent. 
- Using temporary link and need to switch to official fwlink
- Invoke at app installation time can be done silently without prompt user for consent. 

Can be improved:
- merge PowerShell and CMD script so prompt only show up once
