### PR TITLE
Use try_query for CoreWebView2_3 interface

### DIFF
--- a/SampleApps/WebView2APISample/AppWindow.cpp
+++ b/SampleApps/WebView2APISample/AppWindow.cpp
@@ -716,7 +716,7 @@ HRESULT AppWindow::OnCreateCoreWebView2ControllerCompleted(HRESULT result, ICore
             m_creationModeId == IDM_CREATION_MODE_TARGET_DCOMP);
         NewComponent<ControlComponent>(this, &m_toolbar);
 
-        m_webView3 = coreWebView2.query<ICoreWebView2_3>();
+        m_webView3 = coreWebView2.try_query<ICoreWebView2_3>();
         if (m_webView3)
         {
             //! [AddVirtualHostNameToFolderMapping]

--- a/SampleApps/WebView2APISample/SettingsComponent.cpp
+++ b/SampleApps/WebView2APISample/SettingsComponent.cpp
@@ -42,9 +42,12 @@ SettingsComponent::SettingsComponent(
             old->m_settings.try_query<ICoreWebView2ExperimentalSettings>();
         wil::com_ptr<ICoreWebView2ExperimentalSettings> experimental_settings_new;
         experimental_settings_new = m_settings.try_query<ICoreWebView2ExperimentalSettings>();
-        LPWSTR user_agent;
-        CHECK_FAILURE(experimental_settings_old->get_UserAgent(&user_agent));
-        CHECK_FAILURE(experimental_settings_new->put_UserAgent(user_agent));
+        if (experimental_settings_old && experimental_settings_new)
+        {
+            LPWSTR user_agent;
+            CHECK_FAILURE(experimental_settings_old->get_UserAgent(&user_agent));
+            CHECK_FAILURE(experimental_settings_new->put_UserAgent(user_agent));
+        }
         SetBlockImages(old->m_blockImages);
         SetReplaceImages(old->m_replaceImages);
         m_deferScriptDialogs = old->m_deferScriptDialogs;


### PR DESCRIPTION
Use of `query` causes `abort()` call in WIL. Use `try_query` instead and let `nullptr` check handle the case where the interface is not available.