### PR TITLE
Update the product.xml for without elevation

### DIFF
--- a/SampleApps/WV2DeploymentVSInstallerSample/product.xml
+++ b/SampleApps/WV2DeploymentVSInstallerSample/product.xml
@@ -32,6 +32,7 @@
   <!-- Check for RegKey to make sure only install if WebView Run time are not installed -->
   <InstallChecks>
     <RegistryCheck Property="EdgeRuntimeVersionInstalled" Key="HKLM\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Value="pv"/>
+    <RegistryCheck Property="EdgeRuntimeVersionInstalled" Key="HKCU\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Value="pv"/>
   </InstallChecks>
 
   <!-- Defines how to run the Setup package. -->


### PR DESCRIPTION
If Evergreen WebView2 Runtime is installed without elevation, the HKEY_CURRENT_USER regkey is registered.
Currently, if you install without elevation, the installer cannot detect if you have already installed it.
So It might be a good idea to add HKEY_CURRENT_USER regkey in product.xml.

https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-suitable-webview2-runtime-is-already-installed
