### PR TITLE
Fix Downloads button

### DIFF
--- a/SampleApps/WebView2APISample/ViewComponent.h
+++ b/SampleApps/WebView2APISample/ViewComponent.h
@@ -102,7 +102,7 @@ private:
     const int m_downloadsButtonMargin = 50;
     const int m_downloadsButtonWidth = 120;
     const int m_downloadsButtonHeight = 80;
-    HWND m_downloadsButton;
+    HWND m_downloadsButton = nullptr;
 
     EventRegistrationToken m_zoomFactorChangedToken = {};
     EventRegistrationToken m_rasterizationScaleChangedToken = {};


### PR DESCRIPTION
"Toggle Downloads Button" doesn't bring up the button. Because the HWND isn't initialized to nullptr, it doesn't get created later because it contains a junk address, and we only create the actual HWND if it is null. By initializing to nullptr, the menu option will show the button properly.