### PR TITLE
Dispose of unnecessary WebView2 resources when navigating between pages in the WebView2 UWP sample app.

### DIFF
--- a/SampleApps/webview2_sample_uwp/Package.appxmanifest
+++ b/SampleApps/webview2_sample_uwp/Package.appxmanifest
@@ -50,7 +50,6 @@
     <Capability Name="privateNetworkClientServer" />
     <uap:Capability Name="enterpriseAuthentication"/>
     <uap:Capability Name="sharedUserCertificates"/>
-    <rescap:Capability Name="enterpriseCloudSSO" />
     <DeviceCapability Name="location"/>
     <DeviceCapability Name="microphone"/>
     <DeviceCapability Name="webcam"/>    

--- a/SampleApps/webview2_sample_uwp/Pages/AddHostObject.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/AddHostObject.xaml
@@ -2,14 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.AddHostObject"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WebView2_UWP.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -77,5 +77,5 @@ found in the LICENSE file.-->
 
         <controls:WebView2 Grid.Column="1" x:Name="WebView2" />
     </Grid>
-</Page>
+</local:BasePage>
 

--- a/SampleApps/webview2_sample_uwp/Pages/AddHostObject.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/AddHostObject.xaml.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class AddHostObject : Page
+    public sealed partial class AddHostObject : BasePage
     {
         private Bridge _bridge;
 

--- a/SampleApps/webview2_sample_uwp/Pages/BasePage.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/BasePage.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (C) Microsoft Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+using Microsoft.UI.Xaml.Controls;
+using System.Diagnostics;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace WebView2_UWP.Pages
+{
+    public class BasePage : Page
+    {
+        public BasePage()
+        {
+            Unloaded += BasePage_Unloaded;
+        }
+
+        private void BasePage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            // The garbage collector can be slow to dispose of the
+            // webviews. Manually free the resources being used by
+            // the webviews since they are no longer needed after
+            // the page has been unloaded.
+            CloseAllWebViews(this);
+        }
+
+        private void CloseAllWebViews(DependencyObject root)
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(root); i++)
+            {
+                var childVisual = VisualTreeHelper.GetChild(root, i);
+                CloseAllWebViews(childVisual);
+
+                if (childVisual is WebView2 webView)
+                {
+                    webView.Close();
+                }
+            }
+        }
+    }
+}

--- a/SampleApps/webview2_sample_uwp/Pages/Browser.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/Browser.xaml
@@ -2,13 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.Browser"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -45,4 +46,4 @@ found in the LICENSE file.-->
         <Rectangle Grid.Row="2" Fill="LightGray"/>
         <TextBlock x:Name="StatusBar" Text="WebView2" VerticalAlignment="Center" Grid.Row="2" Margin="10,0,10,0"/>
     </Grid>
-</Page>
+</local:BasePage>

--- a/SampleApps/webview2_sample_uwp/Pages/Browser.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/Browser.xaml.cs
@@ -19,13 +19,13 @@ using Windows.UI.Xaml.Input;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class Browser : Page
+    public sealed partial class Browser : BasePage
     {
         private string _homeUrl = "https://developer.microsoft.com/en-us/microsoft-edge/webview2/";
 
         public Browser()
         {
-            this.InitializeComponent();
+            InitializeComponent();
             AddressBar.Text = _homeUrl;
 
             WebView2.CoreWebView2Initialized += WebView2_CoreWebView2Initialized;
@@ -36,7 +36,11 @@ namespace WebView2_UWP.Pages
             WebView2.Source = new Uri(AddressBar.Text);
         }
 
+#if USE_WEBVIEW2_SMOKETEST
         private async void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+#else
+        private void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+#endif
         {
             if (args.Exception != null)
             {
@@ -59,7 +63,7 @@ namespace WebView2_UWP.Pages
         }
 
         // <DownloadStarting>
-        private async void CoreWebView2_DownloadStarting(CoreWebView2 sender, CoreWebView2DownloadStartingEventArgs args)
+        private void CoreWebView2_DownloadStarting(CoreWebView2 sender, CoreWebView2DownloadStartingEventArgs args)
         {
             // Developer can obtain a deferral for the event so that the CoreWebView2
             // doesn't examine the properties we set on the event args until
@@ -142,13 +146,17 @@ namespace WebView2_UWP.Pages
             Debug.WriteLine(message);
         }
 
-        private async void WebView2_NavigationStarting(WebView2 sender, CoreWebView2NavigationStartingEventArgs args)
+        private void WebView2_NavigationStarting(WebView2 sender, CoreWebView2NavigationStartingEventArgs args)
         {
             RefreshButton.IsEnabled = false;
             CancelButton.IsEnabled = true;
         }
 
+#if USE_WEBVIEW2_SMOKETEST
         private async void WebView2_NavigationCompleted(WebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
+#else
+        private void WebView2_NavigationCompleted(WebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
+#endif
         {
             StatusUpdate("Navigation complete");
 

--- a/SampleApps/webview2_sample_uwp/Pages/ExecuteJavascript.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/ExecuteJavascript.xaml
@@ -2,14 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.ExecuteJavascript"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WebView2_UWP"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -83,5 +83,5 @@ found in the LICENSE file.-->
 
         <controls:WebView2 Grid.Column="1" x:Name="WebView2" />
     </Grid>
-</Page>
+</local:BasePage>
 

--- a/SampleApps/webview2_sample_uwp/Pages/ExecuteJavascript.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/ExecuteJavascript.xaml.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class ExecuteJavascript : Page
+    public sealed partial class ExecuteJavascript : BasePage
     {
         Dictionary<string, string> codeSnippets = new Dictionary<string, string>()
         {
@@ -29,7 +29,7 @@ namespace WebView2_UWP.Pages
             WebView2.Source = new Uri("http://appassets.html.example/execute_javascript.html");
         }
 
-        private async void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+        private void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
         {
             sender.CoreWebView2.SetVirtualHostNameToFolderMapping("appassets.html.example", "html", CoreWebView2HostResourceAccessKind.Allow);
         }

--- a/SampleApps/webview2_sample_uwp/Pages/NewWindow.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/NewWindow.xaml
@@ -2,14 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.NewWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WebView2_UWP.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -78,4 +78,4 @@ found in the LICENSE file.-->
         </Grid>
 
     </Grid>
-</Page>
+</local:BasePage>

--- a/SampleApps/webview2_sample_uwp/Pages/NewWindow.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/NewWindow.xaml.cs
@@ -10,7 +10,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class NewWindow : Page
+    public sealed partial class NewWindow : BasePage
     {
         public enum OptionEnum
         {
@@ -65,7 +65,7 @@ namespace WebView2_UWP.Pages
             WebView2.Source = new Uri("http://appassets.html.example/new_window.html");
         }
 
-        private async void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+        private void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
         {
             sender.CoreWebView2.SetVirtualHostNameToFolderMapping("appassets.html.example", "html", CoreWebView2HostResourceAccessKind.Allow);
             sender.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;

--- a/SampleApps/webview2_sample_uwp/Pages/PopupsAndDialogs.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/PopupsAndDialogs.xaml
@@ -2,14 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.PopupsAndDialogs"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WebView2_UWP.Pages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -100,4 +100,4 @@ found in the LICENSE file.-->
 
         <controls:WebView2 Grid.Column="1" x:Name="WebView2" />
     </Grid>
-</Page>
+</local:BasePage>

--- a/SampleApps/webview2_sample_uwp/Pages/PopupsAndDialogs.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/PopupsAndDialogs.xaml.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class PopupsAndDialogs : Page
+    public sealed partial class PopupsAndDialogs : BasePage
     {
         public PopupsAndDialogs()
         {
@@ -23,7 +23,7 @@ namespace WebView2_UWP.Pages
             WebView2.Source = new Uri("http://appassets.html.example/popups_and_dialogs.html");
         }
 
-        private async void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+        private void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
         {
             WebView2.CoreWebView2.SetVirtualHostNameToFolderMapping("appassets.html.example", "html", CoreWebView2HostResourceAccessKind.Allow);
         }

--- a/SampleApps/webview2_sample_uwp/Pages/ScriptDebugging.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/ScriptDebugging.xaml
@@ -2,13 +2,14 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.-->
 
-<Page
+<local:BasePage
     x:Class="WebView2_UWP.Pages.ScriptDebugging"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:WebView2_UWP.Pages"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -46,7 +47,7 @@ found in the LICENSE file.-->
 
         <controls:WebView2 Grid.Column="1" x:Name="WebView2" />
     </Grid>
-</Page>
+</local:BasePage>
 
 
 

--- a/SampleApps/webview2_sample_uwp/Pages/ScriptDebugging.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/ScriptDebugging.xaml.cs
@@ -9,7 +9,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace WebView2_UWP.Pages
 {
-    public sealed partial class ScriptDebugging : Page
+    public sealed partial class ScriptDebugging : BasePage
     {
         public ScriptDebugging()
         {
@@ -17,16 +17,16 @@ namespace WebView2_UWP.Pages
             WebView2.CoreWebView2Initialized += WebView2_CoreWebView2Initialized;
         }
 
-        private async void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
+        private void WebView2_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
         {
             sender.CoreWebView2.SetVirtualHostNameToFolderMapping("appassets.html.example", "html", CoreWebView2HostResourceAccessKind.Allow);
         }
 
-        private async void OnJavaScriptLocalFileButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private void OnJavaScriptLocalFileButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             WebView2.Source = new Uri("http://appassets.html.example/ScenarioJavaScriptDebugIndex.html");
         }
-        private async void OnTypeScriptLocalFileButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private void OnTypeScriptLocalFileButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             WebView2.Source = new Uri("http://appassets.html.example/ScenarioTypeScriptDebugIndex.html");
         }

--- a/SampleApps/webview2_sample_uwp/Pages/SettingsPage.xaml.cs
+++ b/SampleApps/webview2_sample_uwp/Pages/SettingsPage.xaml.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using webview2_sample_uwp;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
+using Windows.UI.Core;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -160,6 +161,14 @@ namespace WebView2_UWP.Pages
                             Value = sender.CoreWebView2.Environment.UserDataFolder
                         });
                     }
+
+                    // The garbage collector can be slow to dispose of the
+                    // webview. Manually free the resources being used by
+                    // the webview since it is no longer needed.
+                    var ignored = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                    {
+                        webview2.Close();
+                    });
                 };
             await webview2.EnsureCoreWebView2Async();
         }

--- a/SampleApps/webview2_sample_uwp/webview2_sample_uwp.csproj
+++ b/SampleApps/webview2_sample_uwp/webview2_sample_uwp.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Pages\AddHostObject.xaml.cs">
       <DependentUpon>AddHostObject.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\BasePage.cs" />
     <Compile Include="Pages\Browser.xaml.cs">
       <DependentUpon>Browser.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
In the WebView2 UWP sample app, when navigating between pages, the garbage collector takes a long time to activate and does not remove WebView2 resources in a reasonable amount of time. This leaves behind all the render processes and other resources which can bog down low memory systems. This PR "closes" all WebView controls which are on a page that is being unloaded and thus releases all significant resources which are used by those controls.