### PR TITLE
USE_WEBVIEW2_EXPERIMENTAL in WPF sample app

### DIFF
--- a/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
+++ b/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
@@ -12,12 +12,15 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
     <PlatformTarget>x64</PlatformTarget>
+    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x86'">
     <PlatformTarget>x86</PlatformTarget>
+    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <ItemGroup>
     <Content Include="assets\EdgeWebView2-80.jpg">

--- a/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
+++ b/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
@@ -8,19 +8,22 @@
     <Product>WebView2 WPF Sample Browser App</Product>
     <Copyright>Copyright ©2020</Copyright>
     <NoWin32Manifest>true</NoWin32Manifest>
-    <Configurations>Debug;Release</Configurations>
+    <Configurations>Debug Stable APIs;Release Stable APIs;Debug Experimental APIs;Release Experimental APIs</Configurations>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug Experimental APIs'">
+	<DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release Experimental APIs'">
+	<DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x86'">
     <PlatformTarget>x86</PlatformTarget>
-    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DefineConstants>USE_WEBVIEW2_EXPERIMENTAL</DefineConstants>	  
   </PropertyGroup>
   <ItemGroup>
     <Content Include="assets\EdgeWebView2-80.jpg">

--- a/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.sln
+++ b/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.sln
@@ -7,14 +7,20 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebView2WpfBrowser", "WebVi
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug Experimental APIs|Any CPU = Debug Experimental APIs|Any CPU
+		Debug Stable APIs|Any CPU = Debug Stable APIs|Any CPU
+		Release Experimental APIs|Any CPU = Release Experimental APIs|Any CPU
+		Release Stable APIs|Any CPU = Release Stable APIs|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug Experimental APIs|Any CPU.ActiveCfg = Debug Experimental APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug Experimental APIs|Any CPU.Build.0 = Debug Experimental APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug Stable APIs|Any CPU.ActiveCfg = Debug Stable APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Debug Stable APIs|Any CPU.Build.0 = Debug Stable APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release Experimental APIs|Any CPU.ActiveCfg = Release Experimental APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release Experimental APIs|Any CPU.Build.0 = Release Experimental APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release Stable APIs|Any CPU.ActiveCfg = Release Stable APIs|Any CPU
+		{EE405166-276B-486B-A7C6-D3E5BE2BBB6C}.Release Stable APIs|Any CPU.Build.0 = Release Stable APIs|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
In WPF sample app make macro USE_WEBVIEW2_EXPERIMENTAL defined by default so the new code under it will be compiled.