### PR TITLE
fix: fix outdated reg names in deployment samples

### DIFF
--- a/SampleApps/WV2DeploymentWiXBurnBundleSample/Bundle.wxs
+++ b/SampleApps/WV2DeploymentWiXBurnBundleSample/Bundle.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Bundle Name="WebView2SampleBootstrapper" Version="1.0.0.0" Manufacturer="Microsoft Corp." UpgradeCode="9a57a789-e554-4b42-b0b7-1a16345c2808">
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense"/>
-    <util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Value="EBWebView" Variable="WVRTInstalled" Win64="no" />
+    <util:RegistrySearch Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Value="pv" Variable="WVRTInstalled" Win64="no" />
     <Chain>
       <!-- Step 1: Chain WebView2 RunTime as Prerequisite -->
       <!-- Vital="no" indicate this install will not fail the sequence. If this sequence failed, it will just move on to next install -->

--- a/SampleApps/WV2DeploymentWiXCustomActionSample/Product.wxs
+++ b/SampleApps/WV2DeploymentWiXCustomActionSample/Product.wxs
@@ -7,7 +7,7 @@
 
     <!-- Precondition: Check whether WebView RunTime already installed or not -->
     <Property Id="WVRTINSTALLED">
-      <RegistrySearch Id="WVRTInstalled" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="EBWebView" Type="raw" Win64="no"/>
+      <RegistrySearch Id="WVRTInstalled" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" Win64="no"/>
     </Property>
 
     <!-- Step 1: Define installation folder -->


### PR DESCRIPTION
Currently deployment samples `WV2DeploymentWiXCustomActionSample` and `WV2DeploymentWiXBurnBundleSample` use the reg name `EBWebView` for registry searching, but this entry has already disappeared in recent versions of WVRT (also disappeared in Edge Stable).

![](https://github.com/MicrosoftEdge/WebView2Samples/assets/20179549/54090887-3b70-4e90-90fb-1f061e26963e)

![](https://github.com/MicrosoftEdge/WebView2Samples/assets/20179549/d3937bb9-b278-4db0-8c11-3dee80feae97)

Changed them to `pv`, consistent with `WV2DeploymentVSInstallerSample`.

Also I noticed that these three registry searches were introduced in the same PR (#56). Are there any special considerations for the inconsistency here?

Related commit:

https://github.com/MicrosoftEdge/WebView2Samples/commit/8402697ac016014ca90a0168ef0059428102818e
