### PR TITLE
Update WebView2 Plugin Version

### DIFF
--- a/GettingStartedGuides/HoloLens2_GettingStarted/HoloLens2GetStartedApp/Packages/manifest.json
+++ b/GettingStartedGuides/HoloLens2_GettingStarted/HoloLens2GetStartedApp/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.microsoft.mixedreality.openxr": "file:MixedReality/com.microsoft.mixedreality.openxr-1.8.0.tgz",
     "com.microsoft.mixedreality.toolkit.foundation": "file:MixedReality/com.microsoft.mixedreality.toolkit.foundation-2.8.3.tgz",
     "com.microsoft.mixedreality.toolkit.standardassets": "file:MixedReality/com.microsoft.mixedreality.toolkit.standardassets-2.8.3.tgz",
-    "com.microsoft.mixedreality.webview.unity": "file:MixedReality/com.microsoft.mixedreality.webview.unity-0.17.1-pre.3.tgz",
+    "com.microsoft.mixedreality.webview.unity": "file:MixedReality/com.microsoft.mixedreality.webview.unity-0.17.1-pre.5.tgz",
     "com.unity.collab-proxy": "2.0.3",
     "com.unity.ide.rider": "3.0.20",
     "com.unity.ide.visualstudio": "2.0.18",

--- a/GettingStartedGuides/HoloLens2_GettingStarted/HoloLens2GetStartedApp/Packages/packages-lock.json
+++ b/GettingStartedGuides/HoloLens2_GettingStarted/HoloLens2GetStartedApp/Packages/packages-lock.json
@@ -28,10 +28,12 @@
       }
     },
     "com.microsoft.mixedreality.webview.unity": {
-      "version": "file:MixedReality/com.microsoft.mixedreality.webview.unity-0.17.1-pre.3.tgz",
+      "version": "file:MixedReality/com.microsoft.mixedreality.webview.unity-0.17.1-pre.5.tgz",
       "depth": 0,
       "source": "local-tarball",
-      "dependencies": {}
+      "dependencies": {
+        "com.unity.inputsystem": "1.4.4"
+      }
     },
     "com.unity.collab-proxy": {
       "version": "2.0.3",


### PR DESCRIPTION
Update the version of the WebView2 plugin that the Getting Started sample consumes from 0.17.1-pre.3 to 0.17.1-pre.5.