### PR TITLE
Remove hard coded colors in the WebView2 UWP sample app.

### DIFF
--- a/SampleApps/webview2_sample_uwp/Pages/Browser.xaml
+++ b/SampleApps/webview2_sample_uwp/Pages/Browser.xaml
@@ -20,7 +20,7 @@ found in the LICENSE file.-->
             <RowDefinition Height="50"/>
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Background="LightGray">
+        <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
@@ -43,7 +43,7 @@ found in the LICENSE file.-->
 
         <controls:WebView2 x:Name="WebView2" Grid.Row="1"/>
 
-        <Rectangle Grid.Row="2" Fill="LightGray"/>
+        <Rectangle Grid.Row="2"/>
         <TextBlock x:Name="StatusBar" Text="WebView2" VerticalAlignment="Center" Grid.Row="2" Margin="10,0,10,0"/>
     </Grid>
 </local:BasePage>


### PR DESCRIPTION
Remove hard coded colors in the WebView2 UWP sample app so that the app respects the users chosen system wide app color mode (light/dark). This behavior matches the Edge browser.

The color mode can be set in Settings->Personalization->Colors->Choose Your Default App Mode.