### PR TITLE
Adding net6.0-windows for WinForms and WPF

### DIFF
--- a/SampleApps/WebView2WindowsFormsBrowser/WebView2WindowsFormsBrowser.csproj
+++ b/SampleApps/WebView2WindowsFormsBrowser/WebView2WindowsFormsBrowser.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-	<TargetFrameworks>netcoreapp3.0;net462;net6.0-windows</TargetFrameworks>
-	<UseWindowsForms>true</UseWindowsForms>
+    <TargetFrameworks>netcoreapp3.0;net462;net6.0-windows</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
     <Company>Microsoft</Company>
     <Authors>Hybrid Application Team</Authors>
     <Copyright>Copyright ©2020</Copyright>

--- a/SampleApps/WebView2WindowsFormsBrowser/WebView2WindowsFormsBrowser.csproj
+++ b/SampleApps/WebView2WindowsFormsBrowser/WebView2WindowsFormsBrowser.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net462</TargetFrameworks>
-    <UseWindowsForms>true</UseWindowsForms>
+	<TargetFrameworks>netcoreapp3.0;net462;net6.0-windows</TargetFrameworks>
+	<UseWindowsForms>true</UseWindowsForms>
     <Company>Microsoft</Company>
     <Authors>Hybrid Application Team</Authors>
     <Copyright>Copyright ©2020</Copyright>

--- a/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
+++ b/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-	<OutputType>WinExe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFrameworks>netcoreapp3.0;net462;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Authors>Hybrid Application Team</Authors>

--- a/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
+++ b/SampleApps/WebView2WpfBrowser/WebView2WpfBrowser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net462</TargetFrameworks>
+	<OutputType>WinExe</OutputType>
+    <TargetFrameworks>netcoreapp3.0;net462;net6.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Authors>Hybrid Application Team</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Adding `net6.0-windows` for WinForms and WPF to be regularly tested instead of `netcoreapp3.0` which is out-of-support and can't be run on ARM64 anymore. Unlike `net462` where assemblies can be simply copied over to arm64, `net6.0` requires custom built assemblies for arm64, for example by running `dotnet publish --framework net6.0-windows -r win-arm64 --self-contained true`. This will be followed with updating our vendor tests instructions on how to test `net6.0-windows` instead of `netcoreapp3.0` on arm64.