### PR TITLE
Skip updating Win SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,10 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
-      - name: "Update windows SDK"
-        uses: fbactions/setup-winsdk@v1
-        with:
-          winsdk-build-version: 18362
+      # - name: "Update windows SDK"
+      #   uses: fbactions/setup-winsdk@v1
+      #   with:
+      #     winsdk-build-version: 18362
 
       - name: setup-msbuild
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
Updating WinSDK in CI is no longer required and the static WinSDK download link has been obsolete (404). This PR removes the WinSDK update step from the CI workflow to prevent unnecessary failures.